### PR TITLE
Fix suffix in image file names for different screen densities

### DIFF
--- a/src/pages/Image.js
+++ b/src/pages/Image.js
@@ -43,7 +43,7 @@ export default class View extends Component {
             <code>Image</code> is used to render images. Images may either be bundled with the app as assets, or downloaded from the web.
           </div>
           <div style={styles.p}>
-            To bundle an image in the app, <code>require()</code> the image file just as you would any other file. When loading bundled images, the same images are used to render on both iOS and Android. Writing <code>require('./test.png')</code> will choose the most appropriate image for the device size: <code>test.png</code>, <code>test.png@2x</code>, or <code>test.png@3x</code>.
+            To bundle an image in the app, <code>require()</code> the image file just as you would any other file. When loading bundled images, the same images are used to render on both iOS and Android. Writing <code>require('./test.png')</code> will choose the most appropriate image for the device size: <code>test.png</code>, <code>test@2x.png</code>, or <code>test@3x.png</code>.
           </div>
           <div style={styles.p}>
             For images downloaded from the web, layout works differently than for most other elements. Since the dimensions of the image aren't known until the image is downloaded, images can't be automatically stretched with <code>{'flex: 1'}</code>. Instead, you must specify dimensions in the style prop, e.g. <code>{'style={{width: 100, height: 100}}'}</code>. React Native is evolving quickly, however, and this behavior may change - when in doubt, try a few different layouts and see what happens!


### PR DESCRIPTION
E.g. it should be test@2x.png instead of test.png@2x