### PR TITLE
Fix height value in TimingDriver example

### DIFF
--- a/src/pages/ShoutemUIAnimation.js
+++ b/src/pages/ShoutemUIAnimation.js
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
   },
   image: {
     width: Dimensions.get('window').width,
-    height: Dimensions.get('window').width,
+    height: Dimensions.get('window').height,
   },
 })
 


### PR DESCRIPTION
There is a typo in the TimingDriver example about the image's width and height.

