### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/pages/Flexbox.js
+++ b/src/pages/Flexbox.js
@@ -17,7 +17,7 @@ export default class Toggle extends Component {
   }
 
   renderOption = (option) => {
-    const {value, options} = this.props
+    const {value} = this.props
 
     return (
       <TouchableOpacity


### PR DESCRIPTION
Why extract **options** property from props in **renderOption** method?