### PR TITLE
Upgrade node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "6.3.1"
+    "node": "9.5.0"
   },
   "author": "Devin Abbott <devinabbott@gmail.com> (http://github.com/dabbott)",
   "license": "MIT",


### PR DESCRIPTION
- `6.3.1` is too old
- I've successfully built this site with node `8.9.0` and `9.5.0`. 
- I can find anywhere in the code and document regards why we have to stick with `6.3.1`.

@dabbott As your recommendation, I've change the commit to upgrade instead of remove the config.
