### PR TITLE
Fix SyntaxError in the Networking Redux example

### DIFF
--- a/src/pages/NetworkingRedux.js
+++ b/src/pages/NetworkingRedux.js
@@ -97,7 +97,7 @@ const mapStateToProps = (state) => ({
   posts: state.posts,
 })
 
-export default class App extends Component {
+export class App extends Component {
 
   componentWillMount() {
     const {dispatch} = this.props


### PR DESCRIPTION
Fix the "SyntaxError: Only one default export allowed per module. (128:0)"