### PR TITLE
CLEAR_POSTS action is not handled in Networking with Redux

### DIFF
--- a/src/pages/NetworkingRedux.js
+++ b/src/pages/NetworkingRedux.js
@@ -79,6 +79,9 @@ export const reducer = (state = initialState, action) => {
 
       return {...state, loading: false, posts: payload}
     }
+    case types.CLEAR_POSTS: {
+      return {...state, loading: false, posts: []}
+    }
   }
 
   return state

--- a/src/pages/NetworkingRedux.js
+++ b/src/pages/NetworkingRedux.js
@@ -65,7 +65,6 @@ const initialState = {
 }
 
 export const reducer = (state = initialState, action) => {
-  const {todos} = state
   const {type, payload, error} = action
 
   switch (type) {


### PR DESCRIPTION
First off, thank you for this amazing project. It's easy to understand but comprehensive enough to get to know essential 3rd part technologies around RN, which normally is very hard without the tutorial.

# What does the PR do?

While playing around the example of 8.1 Networking/With Redux, I found that the reducer doesn't handle `CLEAR_POSTS` action. I implemented it in this PR.

I tested it by commenting out fetch post action in `App.js`,

```js
refresh = async () => {
    const {dispatch} = this.props

    // We can await the completion of dispatch, so long as we returned a promise.
    await dispatch(actionCreators.clearPosts())

//    dispatch(actionCreators.fetchPosts())
}
```

and made sure it clears the feed up. 

![react_native_express_-_networking_with_redux](https://user-images.githubusercontent.com/5956615/37877324-800d1f38-3051-11e8-83ca-6462d9cdc4bb.png)
