### PR TITLE
Fixed Links in quick_start page.

### DIFF
--- a/pages/environment/quick_start.mdx
+++ b/pages/environment/quick_start.mdx
@@ -46,4 +46,4 @@ Try changing the text in `App.js`, saving the file, and watching it update on yo
 
 ### Up next
 
-Now that you have a project set up, let's jump into some of the important JavaScript language features you'll be using. If you're already familiar with each, skip to [React](react) to learn more about React. If you're already familiar with React, skip to [Core Components](core_components) to learn about the components provided by the React Native framework.
+Now that you have a project set up, let's jump into some of the important JavaScript language features you'll be using. If you're already familiar with each, skip to [React](../react) to learn more about React. If you're already familiar with React, skip to [Core Components](../core_components) to learn about the components provided by the React Native framework.


### PR DESCRIPTION
The links to `React` and `Core Components` pages in `quick_start` page were leading to a 404 page.

[Link to the page](https://www.reactnative.express/environment/quick_start)