### PR TITLE
Fix typo in gestures.mdx and gesture_handlers.mdx

### DIFF
--- a/pages/app/gestures.mdx
+++ b/pages/app/gestures.mdx
@@ -3,6 +3,6 @@ We use gestures to support user interactions that are more complex than pressing
 There are 2 common approaches:
 
 - `PanResponder` - The built-in gesture API
-- `react-native-gesture-hander` - A library that bridges built-in native gesture handling code
+- `react-native-gesture-handler` - A library that bridges built-in native gesture handling code
 
 Let's look at each of these in more detail.

--- a/pages/app/gestures/gesture_handlers.mdx
+++ b/pages/app/gestures/gesture_handlers.mdx
@@ -1,6 +1,6 @@
 import panGestureHandler from '../../../examples/files/gestures/panGestureHandler.tsx'
 
-With the library [`react-native-gesture-hander`](https://github.com/software-mansion/react-native-gesture-handler), we can use the native gesture recognition APIs.
+With the library [`react-native-gesture-handler`](https://github.com/software-mansion/react-native-gesture-handler), we can use the native gesture recognition APIs.
 
 We can use these React components to detect gestures:
 


### PR DESCRIPTION
Fixed typo from `react-native-gesture-hander` to `react-native-gesture-handler` in `gestures.mdx` and `gesture_handlers.mdx`